### PR TITLE
feat: support open ai compatible api

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,22 +44,65 @@ Once the endpoint is created you can run `runpod-ollama start-proxy`:
    mistral-fb
 ```
 
-This will start the local proxy, and outputs an example to use the endpoint:
+This will start the local proxy, and outputs an example to use the endpoint. You can use [OpenAI compatible API](https://ollama.com/blog/openai-compatibility):
+
+### cURL
+
+```shell
+curl http://127.0.0.1:5001/<endpoint-id>/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+        "model": "llama2",
+        "messages": [
+            {
+                "role": "system",
+                "content": "You are a helpful assistant."
+            },
+            {
+                "role": "user",
+                "content": "Hello!"
+            }
+        ]
+    }'
+```
+
+### OpenAI sdk
 
 ```python
-import litellm
+from openai import OpenAI
 
-response = litellm.completion(
-    "ollama/phi-fb",
-    messages=[
-        {"content": "why the sky is blue?"},
-    ],
-    base_url="http://127.0.0.1:5001/dtaybcvyltprsx",
-    stream=False,
+client = OpenAI(
+    base_url = 'http://127.0.0.1:5001/<endpoint-id>/v1',
+    api_key='ollama', # required, but unused
 )
 
-print(response.choices[0].message["content"])
+response = client.chat.completions.create(
+  model="llama2",
+  messages=[
+    {"role": "system", "content": "You are a helpful assistant"}
+  ]
+)
 ```
+
+## Blog
+
+Check the blog [here](https://medium.com/@pooya.haratian/running-ollama-with-runpod-serverless-and-langchain-6657763f400d)
+
+# Examples
+
+To run the examples, first install the examples dependencies:
+
+```
+$ poetry install --all-extras
+```
+
+# Limitations
+
+- Currently stream option is not enabled
+- Error messages are not readable. In case you encountered error, make sure:
+  - The local proxy is running
+  - The model name you provided is right
+- The docker image should be updated. Some models are not working with this version of the Ollama.
 
 ## How it works
 
@@ -145,23 +188,3 @@ and waits until they are resolved.
 ### 4. Client
 
 With the Local Proxy running, you can call the change the Ollama base-url to the local-proxy server, and interact with the Ollama on the server.
-
-## Blog
-
-Check the blog [here](https://medium.com/@pooya.haratian/running-ollama-with-runpod-serverless-and-langchain-6657763f400d)
-
-# Examples
-
-To run the examples, first install the examples dependencies:
-
-```
-$ poetry install --all-extras
-```
-
-# Limitations
-
-- Currently stream option is not enabled
-- Error messages are not readable. In case you encountered error, make sure:
-  - The local proxy is running
-  - The model name you provided is right
-- The docker image should be updated. Some models are not working with this version of the Ollama.

--- a/runpod_ollama/cli.py
+++ b/runpod_ollama/cli.py
@@ -28,7 +28,7 @@ def create_template(model: str, disk_size: int):
     try:
         response = runpod.create_template(
             name=model,
-            image_name="pooyaharatian/runpod-ollama:0.0.8",
+            image_name="pooyaharatian/runpod-ollama:0.0.9",
             docker_start_cmd=model,
             is_serverless=True,
             container_disk_in_gb=disk_size,
@@ -68,9 +68,11 @@ def create_endpoint(
             flashboot=True,
         )
         pod_url = _get_pod_url(response["id"])
-
+        print("Created endpoint:")
         print(response)
-        print("[bold blue]You must manually update the gpu type.[/bold blue]")
+        print(
+            "[bold red]You must manually update the gpu type from 'Edit Endpoint'.[/bold red]"
+        )
         print(f"URL: {pod_url}")
         return response
     except Exception as e:

--- a/runpod_ollama/local_proxy.py
+++ b/runpod_ollama/local_proxy.py
@@ -4,7 +4,6 @@ Runs a local proxy to forward requests to the Runpod Ollama service.
 The API mimicks Ollama's API, but adds a pod_id parameter to the route.
 """
 
-
 from typing import Optional
 from flask import Flask, request
 from runpod_ollama import ENVIRONMENT
@@ -14,7 +13,7 @@ from runpod_ollama.runpod_repository import RunpodRepository
 app = Flask(__name__)
 
 
-@app.route("/<pod_id>/api/<endpoint>", methods=["POST"])
+@app.route("/<pod_id>/<path:endpoint>", methods=["POST"])
 def endpoint(pod_id: str, endpoint: str):
     """Forwards a request to the Runpod Ollama service."""
     data = request.json

--- a/server/runpod_wrapper.py
+++ b/server/runpod_wrapper.py
@@ -1,5 +1,5 @@
 import runpod
-from typing import Any, Literal, TypedDict
+from typing import Any, TypedDict
 import requests
 import sys
 
@@ -7,7 +7,7 @@ import sys
 class HandlerInput(TypedDict):
     """The data for calling the Ollama service."""
 
-    method_name: Literal["generate"]
+    method_name: str
     """The url endpoint of the Ollama service to make a post request to."""
 
     input: Any
@@ -29,7 +29,7 @@ def handler(job: HandlerJob):
     input["input"]["model"] = model
 
     response = requests.post(
-        url=f"{base_url}/api/{input['method_name']}/",
+        url=f"{base_url}/{input['method_name']}",
         headers={"Content-Type": "application/json"},
         json=input["input"],
     )

--- a/server/test_input.json
+++ b/server/test_input.json
@@ -1,10 +1,10 @@
 {
   "input": {
-    "method_name": "generate",
+    "method_name": "api/generate",
     "input": {
       "model": "meta-llama/Llama-2-13b-hf",
       "params": {
-        "prompt": ["The capital of France is P"],
+        "prompt": ["Why the sky is blue?"],
         "stream": true,
         "max_tokens": 32,
         "temperature": 0.7,


### PR DESCRIPTION
Ollama started supporting OpenAI compatible API. The current proxy assumes all the request endpoints starts with /api/ which is not the case for OpenAI.
In this PR, the proxy is changed to forward any requests to Ollama.